### PR TITLE
fix statement with non-compound name

### DIFF
--- a/src/views/layouts/generator.php
+++ b/src/views/layouts/generator.php
@@ -2,7 +2,6 @@
 
 declare (strict_types = 1);
 
-use Yii;
 use yii\gii\controllers\DefaultController;
 use yii\gii\Generator;
 use yii\helpers\Html;

--- a/src/views/layouts/main.php
+++ b/src/views/layouts/main.php
@@ -1,6 +1,5 @@
 <?php
 
-use Yii;
 use yii\gii\GiiAsset;
 use yii\helpers\Html;
 use yii\web\View;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | PHP Warning - The use statement with non-compound name 'Yii' has no effect

```
$ composer run test
> phpunit
PHPUnit 10.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.14
Configuration: /home/biladina/git/gii/phpunit.xml.dist

..................SSSSSSSSS..........................             53 / 53 (100%)

Time: 00:00.131, Memory: 6.00 MB

OK, but some tests were skipped!
Tests: 53, Assertions: 177, Skipped: 9.
```
![Untitled](https://github.com/yii2-extensions/gii/assets/10651085/fc62efd3-b611-4e2c-b15c-ebefeb03ad12)

